### PR TITLE
[sc-330843][pi-system][TO_BE_MANUALLY_TESTED] Adds supported Python versions 3.11, 3.12, 3.13, 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.5.0 - Enhancement release - 2026-07-20
+
+- Added supported Python versions: 3.11, 3.12, 3.13, 3.14
+
 ## [Version 1.4.2](https://github.com/dataiku/dss-plugin-pi-server/releases/tag/v1.4.2) - Bugfix release - 2026-04-17
 
 - Fix issue with writing single value to static AF attributes

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -5,7 +5,11 @@
     "PYTHON37",
     "PYTHON38",
     "PYTHON39",
-    "PYTHON310"
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
   ],
   "corePackagesSet": "AUTO",
   "forceConda": false,

--- a/plugin.json
+++ b/plugin.json
@@ -1,14 +1,17 @@
 {
-    "id": "pi-system",
-    "version": "1.4.2",
-    "meta": {
-        "label": "PI System",
-        "description": "Retrieve data from your OSIsoft PI System servers",
-        "author": "Dataiku (Alex Bourret)",
-        "icon": "icon-pi-system icon-cogs",
-        "tags": ["Connector", "Manufacturing"],
-        "url": "https://www.dataiku.com/product/plugins/pi-system/",
-        "licenseInfo": "Apache Software License",
-        "supportLevel": "NOT_SUPPORTED"
-    }
+  "id": "pi-system",
+  "version": "1.5.0",
+  "meta": {
+    "label": "PI System",
+    "description": "Retrieve data from your OSIsoft PI System servers",
+    "author": "Dataiku (Alex Bourret)",
+    "icon": "icon-pi-system icon-cogs",
+    "tags": [
+      "Connector",
+      "Manufacturing"
+    ],
+    "url": "https://www.dataiku.com/product/plugins/pi-system/",
+    "licenseInfo": "Apache Software License",
+    "supportLevel": "NOT_SUPPORTED"
+  }
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: `NOT_SUPPORTED`
- Added supported Python versions: `3.11, 3.12, 3.13, 3.14`
- Bumped plugin version: `1.5.0`

## Details:
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.11 code-env: ✅
 - Creation of Python 3.12 code-env: ✅
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.11 code-env: ✅
 - Creation of Python 3.12 code-env: ✅
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅