### PR TITLE
Preview dataset v2

### DIFF
--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -301,12 +301,16 @@ app.controller('AfExplorerFormCtrl', [
 
         $scope.showDatasetPreviewModal = function() {
             const modalScope = $scope.$new();
+            modalScope.ui = {
+                previewAttributeSearch: ""
+            };
 
             function rebuildGroupedSelectedAttributes() {
                 modalScope.groupedSelectedAttributes = buildGroupedAttributesResult(
                     $scope.config.outputSelectedAttributes,
                     "parent_element_path",
-                    "parent_element"
+                    "parent_element",
+                    modalScope.ui.previewAttributeSearch
                 );
             }
 
@@ -315,6 +319,13 @@ app.controller('AfExplorerFormCtrl', [
             modalScope.$watchCollection(
                 function() {
                     return $scope.config.outputSelectedAttributes;
+                },
+                rebuildGroupedSelectedAttributes
+            );
+
+            modalScope.$watch(
+                function() {
+                    return modalScope.ui.previewAttributeSearch;
                 },
                 rebuildGroupedSelectedAttributes
             );
@@ -1196,11 +1207,11 @@ app.controller('AfExplorerFormCtrl', [
             $scope.refreshAttributeSection();
         };
 
-        function attributeMatchesSearch(attribute_name, group_name, attribute_description="") {
-            if ($scope.ui.attributeSearch === "") {
+        function attributeMatchesSearch(searchText, attribute_name, group_name, attribute_description="") {
+            if (!searchText) {
                 return true;
             }
-            const lowercasedSearch = $scope.ui.attributeSearch.toLowerCase();
+            const lowercasedSearch = searchText.toLowerCase();
             const groupNameMatches = group_name.toLowerCase().includes(lowercasedSearch);
             const attributeNameMatches = attribute_name.toLowerCase().includes(lowercasedSearch);
             let attributeDescriptionMatches = false;
@@ -1244,7 +1255,7 @@ app.controller('AfExplorerFormCtrl', [
             } ];
         }
 
-        function initConflatedAttribute(attr, group) {
+        function initConflatedAttribute(attr, group, searchText) {
             const conflatedAttribute = {
                 title: attr.title,
                 description: attr.description,
@@ -1261,7 +1272,7 @@ app.controller('AfExplorerFormCtrl', [
                 paths: [],
                 data_type: attr.data_type,
                 data_types: [],
-                isDisplayed: attributeMatchesSearch(attr.title, group.value, attr.description),
+                isDisplayed: attributeMatchesSearch(searchText, attr.title, group.value, attr.description),
                 category_names: attr.category_names,
                 conflicting_categories: false
             };
@@ -1307,12 +1318,12 @@ app.controller('AfExplorerFormCtrl', [
             }
         }
 
-        function conflateAttributes(groupingKey, titleKey) {
+        function conflateAttributes(groupingKey, titleKey, searchText) {
             return (acc, attr) => {
                 const groups = getGroups(attr, groupingKey, titleKey);
                 for (const group of groups) {
                     if (!acc[group.key]) {
-                        acc[group.key] = initConflatedAttribute(attr, group);
+                        acc[group.key] = initConflatedAttribute(attr, group, searchText);
                     }
                     updateConflatedAttribute(acc[group.key], attr);
                 }
@@ -1349,8 +1360,8 @@ app.controller('AfExplorerFormCtrl', [
             }
         }
 
-        function buildAggregatedAttributes(attributes, groupingKey, titleKey) {
-            let deduplicatedAttributes = Object.values(attributes.reduce(conflateAttributes(groupingKey, titleKey), {})).map(conflatedAttribute => {
+        function buildAggregatedAttributes(attributes, groupingKey, titleKey, searchText) {
+            let deduplicatedAttributes = Object.values(attributes.reduce(conflateAttributes(groupingKey, titleKey, searchText), {})).map(conflatedAttribute => {
                 if ($scope.ui.onlyDisplayCommon && conflatedAttribute.parent_elements.length < $scope.ui.clickedNodes.length) {
                     conflatedAttribute.isDisplayed = false;
                 }
@@ -1374,8 +1385,8 @@ app.controller('AfExplorerFormCtrl', [
             };
         }
 
-        function buildGroupedAttributesResult(attributes, groupingKey, titleKey) {
-            const groups = buildAggregatedAttributes(attributes, groupingKey, titleKey);
+        function buildGroupedAttributesResult(attributes, groupingKey, titleKey, searchText) {
+            const groups = buildAggregatedAttributes(attributes, groupingKey, titleKey, searchText);
             const displayedGroups = groups.filter(group => !group.isDisplayed);
             // TODO: probably turn this into a reduce
             return {
@@ -1393,12 +1404,14 @@ app.controller('AfExplorerFormCtrl', [
                 attributesWithProperty: buildGroupedAttributesResult(
                     splitAttributes.attributesWithProperty,
                     grouping.group.groupingKey,
-                    grouping.group.titleKey
+                    grouping.group.titleKey,
+                    $scope.ui.attributeSearch
                 ),
                 attributesWithoutProperty: buildGroupedAttributesResult(
                     splitAttributes.attributesWithoutProperty,
                     grouping.fallbackGroup.groupingKey,
-                    grouping.fallbackGroup.titleKey
+                    grouping.fallbackGroup.titleKey,
+                    $scope.ui.attributeSearch
                 )
             };
         }

--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -295,19 +295,17 @@ app.controller('AfExplorerFormCtrl', [
 
         function buildSelectedAttributesTable() {
             return $scope.config.outputSelectedAttributes
-                .filter(attribute => attribute.checked !== false)
-                .map(attribute => ({
-                    title: attribute.title || '',
-                    template_name: attribute.template_name || '',
-                    path: attribute.path || '',
-                    data_type: attribute.data_type || '',
-                    summary_type: formatPreviewValue(attribute.summary_type || []),
-                    boundary_type: attribute.boundary_type || '',
-                    record_boundary_type: attribute.record_boundary_type || '',
-                    summary_duration: attribute.summary_duration || '',
-                    interval: attribute.interval || '',
-                    sync_time: attribute.sync_time || '',
-                }));
+                .reduce((acc, attr) => {
+                    const key = attr.parent_element_path;
+                    if (!acc[key]) {
+                        acc[key] = {
+                            title: attr.parent_element,
+                            attributes: []
+                        }
+                    }
+                    acc[key].attributes.push(attr)
+                    return acc;
+                }, {});
         }
 
         $scope.showDatasetPreviewModal = function() {

--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -109,6 +109,18 @@ const GroupMode = Object.freeze({
     CATEGORY: 'CATEGORY',
 });
 
+function prettifyElementPath(elementPath, databaseName) {
+    console.log("databasename", databaseName)
+    const pathParts = elementPath.split('\\').filter(Boolean);
+    const databaseIndex = pathParts.indexOf(databaseName);
+
+    if (databaseIndex === -1) {
+        return pathParts.join(" > ");
+    }
+
+    return pathParts.slice(databaseIndex + 1).join(" > ");
+}
+
 class Cache {
     constructor(projectKey, server, database) {
         // TODO: include preset in db name
@@ -277,6 +289,7 @@ app.controller('AfExplorerFormCtrl', [
         // $scope.config.attributeCategoryFilter = $scope.config.attributeCategoryFilter || ""
 
         $scope.aggregateDataTypeFields = aggregateDataTypeFields;
+        $scope.prettifyElementPath = prettifyElementPath;
 
         $scope.elementSearchNoMatch = false;
 
@@ -380,8 +393,17 @@ app.controller('AfExplorerFormCtrl', [
             $scope.callPythonDo({ parameterName: "database_name" }).then(function(data) {
                 console.log("database_name", data);
                 $scope.database_name = data.choices;
+                $scope.config.database_title = getDatabaseTitle($scope.config.database_name);
             });
         };
+
+        function getDatabaseTitle(databaseName) {
+            const matchingDatabase = ($scope.database_name || []).find(function(database) {
+                return database.value === databaseName;
+            });
+
+            return matchingDatabase?.label || null;
+        }
 
         $scope.toggleAuthSection = function() {
             $scope.authSectionVisible = !$scope.authSectionVisible;
@@ -514,6 +536,7 @@ app.controller('AfExplorerFormCtrl', [
             $scope.database_name = [];
             $scope.config.server_name = null;
             $scope.config.database_name = null;
+            $scope.config.database_title = null;
             $scope.templateTree = [];
             $scope.config.loadedDatabaseName = null;
             $scope.attributeList = [];
@@ -525,6 +548,7 @@ app.controller('AfExplorerFormCtrl', [
 
         $scope.onServerChanged = function() {
             $scope.config.database_name = null;
+            $scope.config.database_title = null;
             $scope.templateTree = [];
             $scope.config.loadedDatabaseName = null;
             $scope.showTreeData = false;
@@ -533,6 +557,7 @@ app.controller('AfExplorerFormCtrl', [
         };
 
         $scope.onDatabaseChanged = function() {
+            $scope.config.database_title = getDatabaseTitle($scope.config.database_name);
             $scope.templateTree = [];
             $scope.config.loadedDatabaseName = null;
             $scope.showTreeData = false;
@@ -1523,23 +1548,23 @@ app.component('treeNode', {
 });
 
 app.directive('attributeTableBlock', function() {
-    return {
-        restrict: 'A',
-        scope: {
-            title: '<',
-            activeTab: '<',
-            displayElementDropdown: '<',
-            displayPath: '<',
-            excludedColumns: '<',
-            groupMode: '<',
-            elementsByTemplate: '<',
-            groupedAttributes: '=',
-            config: '=',
-            aggregateDataTypeFields: '<',
-            onToggleSelectAllGroupedAttributes: '&',
-            onToggleGroupedAttributes: '&',
-            onIsAtLeastPartiallySelected: '&',
-            onInitElementsDropdown: '&',
+        return {
+            restrict: 'A',
+            scope: {
+                title: '<',
+                activeTab: '<',
+                displayElementDropdown: '<',
+                displayPath: '<',
+                excludedColumns: '<',
+                groupMode: '<',
+                elementsByTemplate: '<',
+                groupedAttributes: '=',
+                config: '=',
+                aggregateDataTypeFields: '<',
+                onToggleSelectAllGroupedAttributes: '&',
+                onToggleGroupedAttributes: '&',
+                onIsAtLeastPartiallySelected: '&',
+                onInitElementsDropdown: '&',
             onIsTemplateAssociatedElementSelected: '&',
             onApplyClickElementsDropdown: '&',
             onCheckAttribute: '&',
@@ -1632,6 +1657,7 @@ app.component('dropdownElements', {
     bindings: {
         elements: '<',
         groupName: '<',
+        databaseName: '<',
         initElementsDropdown: '&',
         isTemplateAssociatedElementSelected: '&',
         applyClickElementsDropdown: '&',
@@ -1641,6 +1667,7 @@ app.component('dropdownElements', {
     controller: function() {
         const ctrl = this;
         ctrl.templatedModeUnselectedElements = [];
+        ctrl.prettifyElementPath = prettifyElementPath;
 
         ctrl.$onInit = function() {
 

--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -293,42 +293,73 @@ app.controller('AfExplorerFormCtrl', [
             return $scope.config.outputSelectedAttributes.flatMap(attribute => attribute.paths).map(getElementPathFromAttributePath);
         }
 
-        function buildSelectedAttributesTable() {
-            return $scope.config.outputSelectedAttributes
-                .reduce((acc, attr) => {
-                    const key = attr.parent_element_path;
-                    if (!acc[key]) {
-                        acc[key] = {
-                            title: attr.parent_element,
-                            attributes: []
-                        }
+        function groupSelectedAttributes() {
+            return (acc, attr) => {
+                const key = attr.parent_element_path;
+                if (!acc[key]) {
+                    acc[key] = {
+                        group_name: attr.parent_element,
+                        checked_ui: attr.checked, // dummy variable for ng-model
+                        checked: CheckboxStatus.CHECKED, // acutally used to determine UI checkbox state
+                        attributes: [],
+                        children_checked: [],
+                        isDisplayed: true,
+                        nbSearchMatches: 0
                     }
-                    acc[key].attributes.push(attr)
-                    return acc;
-                }, {});
+                }
+                console.log("acc", acc[key])
+
+                if (attr.isDisplayed) {
+                    acc[key].children_checked.push(attr.checked);
+                    acc[key].checked_ui = acc[key].checked_ui && attr.checked
+                }
+                acc[key].checked = getCheckboxStatus(acc[key].children_checked);
+                acc[key].attributes.push(attr);
+                acc[key].isDisplayed = acc[key].isDisplayed && !attr.isDisplayed;
+                acc[key].nbSearchMatches += +attr.isDisplayed;
+                return acc;
+            }
         }
+
 
         $scope.showDatasetPreviewModal = function() {
             const modalScope = $scope.$new();
+            modalScope.CheckboxStatus = CheckboxStatus;
+            modalScope.currentlySelectedAttributes = structuredClone($scope.config.outputSelectedAttributes);
+            modalScope.currentlySelectedAttributes.forEach((attribute) => {
+                attribute.checked = true;
+                attribute.isDisplayed = true;
+            });
 
             modalScope.rebuildPreviewDatasetTable = function() {
                 modalScope.previewRows = buildSelectedAttributesTable();
             }
 
-            modalScope.uncheckAttribute = function(row) {
-                $scope.removeAttributeFromSelection(row);
-                modalScope.rebuildPreviewDatasetTable();
+            function buildSelectedAttributesTable() {
+                return modalScope.currentlySelectedAttributes.reduce(groupSelectedAttributes(), {});
             }
 
-            modalScope.clearSelection = function() {
-                $scope.clearOutputSelection();
+            modalScope.toggleElementSelection = function(subgroup) {
+                const shouldCheck = subgroup.checked !== CheckboxStatus.CHECKED;
+                subgroup.attributes.forEach((attribute) => {
+                    attribute.checked = shouldCheck;
+                });
                 modalScope.rebuildPreviewDatasetTable();
-            }
+            };
+
+            modalScope.toggleAttributeSelection = function(row) {
+                row.checked = !row.checked;
+                modalScope.rebuildPreviewDatasetTable();
+            };
+            //
+            // modalScope.clearSelection = function() {
+            //     $scope.clearOutputSelection();
+            //     modalScope.rebuildPreviewDatasetTable();
+            // }
 
             modalScope.previewColumns = [
                 { key: 'title', label: 'Title' },
                 { key: 'template_name', label: 'Template' },
-                { key: 'path', label: 'Path' },
                 { key: 'data_type', label: 'Data type' },
                 { key: 'summary_type', label: 'Summary type' },
                 { key: 'boundary_type', label: 'Boundary type' },
@@ -887,6 +918,7 @@ app.controller('AfExplorerFormCtrl', [
 
         // FIXME: the parent_element_path is not properly present !!! probably because loaded from cache
         // should be properly populated f we want the condition l835 to populate
+        // TODO: check if fixme is up to date
         $scope.applyClickElementsDropdown = function(templateName, element, wasUnselected) {
             $scope.$applyAsync(() => {
                 // TODO: redo everything by templateID

--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -282,45 +282,9 @@ app.controller('AfExplorerFormCtrl', [
 
         $scope.selectedElementPaths = buildSelectedElementPaths()
 
-        function formatPreviewValue(value) {
-            if (Array.isArray(value)) {
-                return value.join(', ');
-            }
-            return value;
-        }
-
         function buildSelectedElementPaths() {
             return $scope.config.outputSelectedAttributes.flatMap(attribute => attribute.paths).map(getElementPathFromAttributePath);
         }
-
-        function groupSelectedAttributes() {
-            return (acc, attr) => {
-                const key = attr.parent_element_path;
-                if (!acc[key]) {
-                    acc[key] = {
-                        group_name: attr.parent_element,
-                        checked_ui: attr.checked, // dummy variable for ng-model
-                        checked: CheckboxStatus.CHECKED, // acutally used to determine UI checkbox state
-                        attributes: [],
-                        children_checked: [],
-                        isDisplayed: true,
-                        nbSearchMatches: 0
-                    }
-                }
-                console.log("acc", acc[key])
-
-                if (attr.isDisplayed) {
-                    acc[key].children_checked.push(attr.checked);
-                    acc[key].checked_ui = acc[key].checked_ui && attr.checked
-                }
-                acc[key].checked = getCheckboxStatus(acc[key].children_checked);
-                acc[key].attributes.push(attr);
-                acc[key].isDisplayed = acc[key].isDisplayed && !attr.isDisplayed;
-                acc[key].nbSearchMatches += +attr.isDisplayed;
-                return acc;
-            }
-        }
-
 
         $scope.showDatasetPreviewModal = function() {
             const modalScope = $scope.$new();
@@ -345,24 +309,12 @@ app.controller('AfExplorerFormCtrl', [
             CreateModalFromTemplate('/plugins/pi-system/resource/pi-system_preview-dataset-modal.html', modalScope);
         };
 
-        $scope.clearOutputSelection = function() {
-            $scope.config.outputSelectedAttributes = [];
-            $scope.selectedElementPaths = []
-            $scope.refreshAttributeSection();
-            // Just need to uncheck the current attribute list as it is
-            // built with the correct checked state when adding any new elements
-            // TODO: switch to mass update in cache
-            Object.values($scope.attributeList).forEach(attribute => {
-                attribute.checked = false;
-            });
-            $scope.refreshAttributeSection();
-        }
-
         $scope.isAtLeastPartiallySelected = function(node) {
             return node.checked === CheckboxStatus.CHECKED || node.checked === CheckboxStatus.PARTIAL_CHECK;
         };
 
         $scope.onAdvancedToggle = function() {
+            // TODO: cleanup the max count things
             if (!$scope.config.show_advanced_parameters) {
                 $scope.config.is_ssl_check_disabled = false;
                 $scope.config.elements_max_count = null;

--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -1229,10 +1229,19 @@ app.controller('AfExplorerFormCtrl', [
             if (Array.isArray(groupingPropertyValues)) {
                 // Not working with different grouping and title key if array of values
                 return groupingPropertyValues.map(( value, index ) => {
-                    return {key: value + "::" + attr.title, value: value};
+                    return {
+                        key: value + "::" + attr.title,
+                        sectionKey: value,
+                        value: value
+                    };
                 });
             }
-            return [ { key: groupingPropertyValues + "::" + attr.title, value: groupTitles } ];
+            return [ {
+                key: groupingPropertyValues + "::" + attr.title,
+                sectionKey: groupingPropertyValues,
+                value: groupTitles,
+                path: groupingPropertyValues
+            } ];
         }
 
         function initConflatedAttribute(attr, group) {
@@ -1240,6 +1249,9 @@ app.controller('AfExplorerFormCtrl', [
                 title: attr.title,
                 description: attr.description,
                 group: group.value,
+                group_key: group.key,
+                section_key: group.sectionKey,
+                group_path: group.path,
                 template_name: attr.template_name,
                 parent_elements: [],
                 checked: null, // Used to determine UI checkbox state
@@ -1310,10 +1322,12 @@ app.controller('AfExplorerFormCtrl', [
 
         function groupAttributesIntoSections() {
             return (acc, attr) => {
-                const key = attr.group;
+                const key = attr.section_key;
                 if (!acc[key]) {
                     acc[key] = {
                         group_name: attr.group,
+                        group_key: key,
+                        group_path: attr.group_path,
                         allChecked: attr.checked,
                         checked: CheckboxStatus.UNCHECKED, // Used to determine UI checkbox state
                         attributes: [],
@@ -1553,6 +1567,8 @@ app.directive('attributeTableBlock', function() {
             scope: {
                 title: '<',
                 activeTab: '<',
+                databaseName: '<?',
+                displayGroupPath: '<?',
                 displayElementDropdown: '<',
                 displayPath: '<',
                 excludedColumns: '<',
@@ -1574,6 +1590,8 @@ app.directive('attributeTableBlock', function() {
         bindToController: true,
         controller: function() {
             const ctrl = this;
+
+            ctrl.prettifyElementPath = prettifyElementPath;
 
             ctrl.getVisibleAttributeColumnCount = function(includeCheckbox) {
                 let count = includeCheckbox ? 5 : 4;

--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -324,52 +324,23 @@ app.controller('AfExplorerFormCtrl', [
 
         $scope.showDatasetPreviewModal = function() {
             const modalScope = $scope.$new();
-            modalScope.CheckboxStatus = CheckboxStatus;
-            modalScope.currentlySelectedAttributes = structuredClone($scope.config.outputSelectedAttributes);
-            modalScope.currentlySelectedAttributes.forEach((attribute) => {
-                attribute.checked = true;
-                attribute.isDisplayed = true;
-            });
 
-            modalScope.rebuildPreviewDatasetTable = function() {
-                modalScope.previewRows = buildSelectedAttributesTable();
+            function rebuildGroupedSelectedAttributes() {
+                modalScope.groupedSelectedAttributes = buildGroupedAttributesResult(
+                    $scope.config.outputSelectedAttributes,
+                    "parent_element_path",
+                    "parent_element"
+                );
             }
 
-            function buildSelectedAttributesTable() {
-                return modalScope.currentlySelectedAttributes.reduce(groupSelectedAttributes(), {});
-            }
+            rebuildGroupedSelectedAttributes();
 
-            modalScope.toggleElementSelection = function(subgroup) {
-                const shouldCheck = subgroup.checked !== CheckboxStatus.CHECKED;
-                subgroup.attributes.forEach((attribute) => {
-                    attribute.checked = shouldCheck;
-                });
-                modalScope.rebuildPreviewDatasetTable();
-            };
-
-            modalScope.toggleAttributeSelection = function(row) {
-                row.checked = !row.checked;
-                modalScope.rebuildPreviewDatasetTable();
-            };
-            //
-            // modalScope.clearSelection = function() {
-            //     $scope.clearOutputSelection();
-            //     modalScope.rebuildPreviewDatasetTable();
-            // }
-
-            modalScope.previewColumns = [
-                { key: 'title', label: 'Title' },
-                { key: 'template_name', label: 'Template' },
-                { key: 'data_type', label: 'Data type' },
-                { key: 'summary_type', label: 'Summary type' },
-                { key: 'boundary_type', label: 'Boundary type' },
-                { key: 'record_boundary_type', label: 'Record boundary type' },
-                { key: 'summary_duration', label: 'Summary duration' },
-                { key: 'interval', label: 'Interval' },
-                { key: 'sync_time', label: 'Sync time' },
-            ];
-
-            modalScope.rebuildPreviewDatasetTable();
+            modalScope.$watchCollection(
+                function() {
+                    return $scope.config.outputSelectedAttributes;
+                },
+                rebuildGroupedSelectedAttributes
+            );
 
             CreateModalFromTemplate('/plugins/pi-system/resource/pi-system_preview-dataset-modal.html', modalScope);
         };
@@ -1275,14 +1246,16 @@ app.controller('AfExplorerFormCtrl', [
         // Attributes are shared between templates
         // Meaning all elements with the same template will share the attributes in this template
         // If multiple elements with the same template are selected, we only show the attribute once
-        function getGroups(attr, groupProperty) {
-            const groupPropertyValues = attr[groupProperty];
-            if (Array.isArray(groupPropertyValues)) {
-                return groupPropertyValues.map(value => {
+        function getGroups(attr, groupingKey, titleKey) {
+            const groupingPropertyValues = attr[groupingKey];
+            const groupTitles = attr[titleKey];
+            if (Array.isArray(groupingPropertyValues)) {
+                // Not working with different grouping and title key if array of values
+                return groupingPropertyValues.map(( value, index ) => {
                     return {key: value + "::" + attr.title, value: value};
                 });
             }
-            return [ { key: groupPropertyValues + "::" + attr.title, value: groupPropertyValues } ];
+            return [ { key: groupingPropertyValues + "::" + attr.title, value: groupTitles } ];
         }
 
         function initConflatedAttribute(attr, group) {
@@ -1345,9 +1318,9 @@ app.controller('AfExplorerFormCtrl', [
             }
         }
 
-        function conflateAttributes(groupProperty) {
+        function conflateAttributes(groupingKey, titleKey) {
             return (acc, attr) => {
-                const groups = getGroups(attr, groupProperty);
+                const groups = getGroups(attr, groupingKey, titleKey);
                 for (const group of groups) {
                     if (!acc[group.key]) {
                         acc[group.key] = initConflatedAttribute(attr, group);
@@ -1385,8 +1358,8 @@ app.controller('AfExplorerFormCtrl', [
             }
         }
 
-        function buildAggregatedAttributes(attributes, groupProperty) {
-            let deduplicatedAttributes = Object.values(attributes.reduce(conflateAttributes(groupProperty), {})).map(conflatedAttribute => {
+        function buildAggregatedAttributes(attributes, groupingKey, titleKey) {
+            let deduplicatedAttributes = Object.values(attributes.reduce(conflateAttributes(groupingKey, titleKey), {})).map(conflatedAttribute => {
                 if ($scope.ui.onlyDisplayCommon && conflatedAttribute.parent_elements.length < $scope.ui.clickedNodes.length) {
                     conflatedAttribute.isDisplayed = false;
                 }
@@ -1397,14 +1370,21 @@ app.controller('AfExplorerFormCtrl', [
 
         function splitAttributesOnProperty(splitProperty) {
             const attributes = $scope.attributeList;
+            function hasGroupingValue(attribute) {
+                const value = attribute?.[splitProperty];
+                if (Array.isArray(value)) {
+                    return value.length > 0;
+                }
+                return !!value;
+            }
             return {
-                attributesWithProperty: attributes.filter((attribute) => attribute?.[splitProperty]),
-                attributesWithoutProperty: attributes.filter((attribute) => !attribute?.[splitProperty])
+                attributesWithProperty: attributes.filter(hasGroupingValue),
+                attributesWithoutProperty: attributes.filter((attribute) => !hasGroupingValue(attribute))
             };
         }
 
-        function buildGroupedAttributesResult(attributes, groupProperty) {
-            const groups = buildAggregatedAttributes(attributes, groupProperty);
+        function buildGroupedAttributesResult(attributes, groupingKey, titleKey) {
+            const groups = buildAggregatedAttributes(attributes, groupingKey, titleKey);
             const displayedGroups = groups.filter(group => !group.isDisplayed);
             // TODO: probably turn this into a reduce
             return {
@@ -1417,27 +1397,31 @@ app.controller('AfExplorerFormCtrl', [
         }
 
         $scope.buildGroupedAttributes = function(grouping) {
-            const splitAttributes = splitAttributesOnProperty('template_name');
+            const splitAttributes = splitAttributesOnProperty(grouping.group.groupingKey);
             return {
                 attributesWithProperty: buildGroupedAttributesResult(
                     splitAttributes.attributesWithProperty,
-                    grouping.groupProperty
+                    grouping.group.groupingKey,
+                    grouping.group.titleKey
                 ),
                 attributesWithoutProperty: buildGroupedAttributesResult(
                     splitAttributes.attributesWithoutProperty,
-                    grouping.fallbackGroupProperty
+                    grouping.fallbackGroup.groupingKey,
+                    grouping.fallbackGroup.titleKey
                 )
             };
         }
 
         function getGrouping() {
-            let groupProperty = 'template_name';
-            if ($scope.groupMode === GroupMode.CATEGORY) {
-                groupProperty = 'category_names';
-            }
             return {
-                groupProperty: groupProperty,
-                fallbackGroupProperty: 'parent_element',
+                group: {
+                    groupingKey: $scope.groupMode === GroupMode.CATEGORY ? 'category_names' : 'template_name',
+                    titleKey: $scope.groupMode === GroupMode.CATEGORY ? 'category_names' : 'template_name'
+                },
+                fallbackGroup: {
+                    groupingKey: 'parent_element_path', // Elements can have duplicated names
+                    titleKey: 'parent_element'
+                },
             }
         }
 
@@ -1611,7 +1595,25 @@ app.directive('attributeTableBlock', function() {
             onUpdateAggregate: '&'
         },
         bindToController: true,
-        controller: function() {},
+        controller: function() {
+            const ctrl = this;
+
+            ctrl.getVisibleAttributeColumnCount = function(includeCheckbox) {
+                let count = includeCheckbox ? 5 : 4;
+
+                if (ctrl.displayPath) {
+                    count += 1;
+                }
+                if (ctrl.groupMode !== 'CATEGORY') {
+                    count += 1;
+                }
+                if (ctrl.groupMode !== 'TEMPLATE') {
+                    count += 1;
+                }
+
+                return count;
+            };
+        },
         controllerAs: 'ctrl',
         templateUrl: "/plugins/pi-system/resource/attribute-table-block.html"
     };

--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -311,6 +311,20 @@ app.controller('AfExplorerFormCtrl', [
         $scope.showDatasetPreviewModal = function() {
             const modalScope = $scope.$new();
 
+            modalScope.rebuildPreviewDatasetTable = function() {
+                modalScope.previewRows = buildSelectedAttributesTable();
+            }
+
+            modalScope.uncheckAttribute = function(row) {
+                $scope.removeAttributeFromSelection(row);
+                modalScope.rebuildPreviewDatasetTable();
+            }
+
+            modalScope.clearSelection = function() {
+                $scope.clearOutputSelection();
+                modalScope.rebuildPreviewDatasetTable();
+            }
+
             modalScope.previewColumns = [
                 { key: 'title', label: 'Title' },
                 { key: 'template_name', label: 'Template' },
@@ -324,10 +338,7 @@ app.controller('AfExplorerFormCtrl', [
                 { key: 'sync_time', label: 'Sync time' },
             ];
 
-            modalScope.previewRows = buildSelectedAttributesTable();
-            modalScope.$watch('config.outputSelectedAttributes', function() {
-                modalScope.previewRows = buildSelectedAttributesTable();
-            }, true);
+            modalScope.rebuildPreviewDatasetTable();
 
             CreateModalFromTemplate('/plugins/pi-system/resource/pi-system_preview-dataset-modal.html', modalScope);
         };
@@ -1451,6 +1462,7 @@ app.controller('AfExplorerFormCtrl', [
             attribute.checked = false;
             $scope.config.outputSelectedAttributes.splice(index, 1);
             $scope.selectedElementPaths = buildSelectedElementPaths();
+            $scope.refreshAttributeSection();
             console.log("Removed attribute from selection", attribute);
         }
 

--- a/resource/attribute-table-block.html
+++ b/resource/attribute-table-block.html
@@ -43,6 +43,7 @@
                     <dropdown-elements
                             elements="ctrl.elementsByTemplate[group.group_name]"
                             group-name="group.group_name"
+                            database-name="ctrl.config.database_title"
                             init-elements-dropdown="ctrl.onInitElementsDropdown({ templateName: templateName })"
                             is-template-associated-element-selected="ctrl.onIsTemplateAssociatedElementSelected({ element: element })"
                             apply-click-elements-dropdown="ctrl.onApplyClickElementsDropdown({ templateName: templateName, element: element, selected: selected })"

--- a/resource/attribute-table-block.html
+++ b/resource/attribute-table-block.html
@@ -24,7 +24,7 @@
         </tr>
         </tbody>
         <tbody
-                ng-repeat="group in ctrl.groupedAttributes.groups track by group.group_name"
+                ng-repeat="group in ctrl.groupedAttributes.groups track by group.group_key"
                 ng-show="!group.isDisplayed">
         <tr class="custom-table__group-row"
             ng-class="{ 'custom-table__group-row--selected': ctrl.onIsAtLeastPartiallySelected({ item: group }) }">
@@ -34,12 +34,16 @@
             </td>
             <td colspan="{{ctrl.getVisibleAttributeColumnCount(false)}}">
                 <div class="custom-table__group-actions">
-                    <div>
-                        <span class="custom-table__group-name">{{group.group_name}}</span>
+                    <div class="custom-table__group-header">
+                        <span class="custom-table__group-name"><strong>{{group.group_name}}</strong></span>
                         <span ng-if="group.nbSearchMatches !== group.attributes.length">
                             - ({{group.nbSearchMatches}}/{{group.attributes.length}} attributes shown)
                         </span>
                     </div>
+                    <span class="custom-table__group-path"
+                          ng-if="ctrl.displayGroupPath && group.group_path">
+                        {{ctrl.prettifyElementPath(group.group_path, ctrl.databaseName)}}
+                    </span>
                     <dropdown-elements
                             elements="ctrl.elementsByTemplate[group.group_name]"
                             group-name="group.group_name"

--- a/resource/attribute-table-block.html
+++ b/resource/attribute-table-block.html
@@ -20,7 +20,7 @@
         </thead>
         <tbody ng-if="ctrl.groupedAttributes.empty">
         <tr class="custom-table__empty-row">
-            <td colspan="{{ctrl.displayPath ? 7 : 6}}">No attributes matched your selection</td>
+            <td colspan="{{ctrl.getVisibleAttributeColumnCount(true)}}">No attributes matched your selection</td>
         </tr>
         </tbody>
         <tbody
@@ -32,7 +32,7 @@
                 <input type="checkbox" ng-model="group.allChecked"
                        ng-change="ctrl.onToggleGroupedAttributes({ group: group })" indeterminate="group.checked">
             </td>
-            <td colspan="{{ctrl.displayPath ? 6 : 5}}">
+            <td colspan="{{ctrl.getVisibleAttributeColumnCount(false)}}">
                 <div class="custom-table__group-actions">
                     <div>
                         <span class="custom-table__group-name">{{group.group_name}}</span>

--- a/resource/dropdown-elements.html
+++ b/resource/dropdown-elements.html
@@ -19,8 +19,11 @@
             class="elements-dropdown--element"
             ng-class="{'elements-dropdown--element-separator': $last}"
         >
-            <span>
-                {{element.title}}
+            <span class="elements-dropdown--element-label">
+                <span class="elements-dropdown--element-name">{{element.title}}</span>
+                <span class="elements-dropdown--element-path">
+                    {{ctrl.prettifyElementPath(element.path, ctrl.databaseName)}}
+                </span>
             </span>
             <i class="dku-icon-eye-16" ng-show="ctrl.isElementSelected(element)"></i>
         </li>
@@ -29,8 +32,11 @@
             ng-click="ctrl.onClickElement(element, $event)"
             class="elements-dropdown--element"
         >
-            <span>
-                {{element.title}}
+            <span class="elements-dropdown--element-label">
+                <span class="elements-dropdown--element-name">{{element.title}}</span>
+                <span class="elements-dropdown--element-path">
+                    {{ctrl.prettifyElementPath(element.path, ctrl.databaseName)}}
+                </span>
             </span>
             <i class="dku-icon-eye-16" ng-show="ctrl.isElementSelected(element)"></i>
         </li>

--- a/resource/pi-system_af-explorer.css
+++ b/resource/pi-system_af-explorer.css
@@ -598,6 +598,29 @@ pi-system-auth-banner {
     justify-content: space-between;
 }
 
+.elements-dropdown--element-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.elements-dropdown--element-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.elements-dropdown--element-path {
+    color: #9A9A9A;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .elements-dropdown--element-separator {
     border-bottom: 1px solid #d9d9d9;
 }

--- a/resource/pi-system_af-explorer.css
+++ b/resource/pi-system_af-explorer.css
@@ -377,7 +377,18 @@ pi-system-auth-banner {
     align-items: center;
 }
 
+.custom-table__group-header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
 .custom-table__group-name {
+    font-weight: 600;
+}
+
+.custom-table__group-path {
+    margin-left: auto;
 }
 
 .custom-table__attribute-title-info {

--- a/resource/pi-system_af-explorer.css
+++ b/resource/pi-system_af-explorer.css
@@ -25,6 +25,10 @@
     height: 75vh;
 }
 
+.pi-system-preview-dataset-modal__search {
+    margin-bottom: 12px;
+}
+
 .h100.mainPane {
     overflow: visible;
 }

--- a/resource/pi-system_af-explorer.html
+++ b/resource/pi-system_af-explorer.html
@@ -134,7 +134,6 @@
                         ng-if="groupedAttributesFallbackGrouping && !groupedAttributesFallbackGrouping.empty"
                         grouped-attributes="groupedAttributesFallbackGrouping"
                         config="config"
-                        database-name="config.database_name"
                         display-path="ui.displayPath"
                         elements-by-template="elementsByTemplate"
                         title="getAttributeTableTitle(true)"
@@ -156,7 +155,6 @@
                         attribute-table-block
                         grouped-attributes="groupedAttributes"
                         config="config"
-                        database-name="config.database_name"
                         display-path="ui.displayPath"
                         elements-by-template="elementsByTemplate"
                         title="getAttributeTableTitle()"

--- a/resource/pi-system_af-explorer.html
+++ b/resource/pi-system_af-explorer.html
@@ -134,6 +134,7 @@
                         ng-if="groupedAttributesFallbackGrouping && !groupedAttributesFallbackGrouping.empty"
                         grouped-attributes="groupedAttributesFallbackGrouping"
                         config="config"
+                        database-name="config.database_name"
                         display-path="ui.displayPath"
                         elements-by-template="elementsByTemplate"
                         title="getAttributeTableTitle(true)"
@@ -155,6 +156,7 @@
                         attribute-table-block
                         grouped-attributes="groupedAttributes"
                         config="config"
+                        database-name="config.database_name"
                         display-path="ui.displayPath"
                         elements-by-template="elementsByTemplate"
                         title="getAttributeTableTitle()"

--- a/resource/pi-system_preview-dataset-modal.html
+++ b/resource/pi-system_preview-dataset-modal.html
@@ -12,32 +12,53 @@
             No attributes selected yet.
         </div>
         <div ng-if="config.outputSelectedAttributes.length">
-            <p>{{config.outputSelectedAttributes.length}} selected attribute(s)</p>
-            <div class="scroll">
-                <table class="table table-striped table-condensed">
-                    <thead>
-                        <tr>
-                            <th></th>
-                            <th ng-repeat="column in previewColumns">{{column.label}}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr ng-repeat-start="(groupKey, subgroup) in previewRows">
-                            <td colspan="{{previewColumns.length + 1}}"><strong>{{subgroup.title}}</strong></td>
-                        </tr>
-                        <tr ng-repeat="row in subgroup.attributes track by row.path" ng-repeat-end>
-                            <td>
-                                <input
-                                    type="checkbox"
-                                    ng-model="row.checked"
-                                    ng-change="uncheckAttribute(row)">
-                            </td>
-                            <td ng-repeat="column in previewColumns">
-                                {{column.key === 'summary_type' && row[column.key] ? row[column.key].join(', ') : row[column.key]}}
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+            <div class="attribute-table-block">
+                <div class="attribute-table-block__title">
+                    <strong>{{config.outputSelectedAttributes.length}} selected attribute(s)</strong>
+                </div>
+                <div class="scroll">
+                    <table class="custom-table">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th ng-repeat="column in previewColumns">{{column.label}}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr
+                                    ng-repeat-start="(groupKey, subgroup) in previewRows"
+                                    class="custom-table__group-row custom-table__group-row--selected">
+                                <td>
+                                    <input
+                                            type="checkbox"
+                                            ng-checked="subgroup.checked_ui"
+                                            ng-click="toggleElementSelection(subgroup)"
+                                            indeterminate="subgroup.checked">
+                                </td>
+                                <td colspan="{{previewColumns.length + 1}}"><strong>{{subgroup.group_name}}</strong></td>
+                            </tr>
+                            <tr
+                                    ng-repeat="row in subgroup.attributes track by row.path"
+                                    ng-repeat-end
+                                    ng-class="{ 'custom-table__attribute-row--selected': row.checked }">
+                                <td>
+                                    <input
+                                        type="checkbox"
+                                        ng-checked="row.checked"
+                                        ng-click="toggleAttributeSelection(row)">
+                                </td>
+                                <td ng-repeat="column in previewColumns">
+                                    <div ng-if="column.key === 'title'" class="custom-table__attribute-title-info">
+                                        {{row[column.key]}}
+                                    </div>
+                                    <span ng-if="column.key !== 'title'">
+                                        {{column.key === 'summary_type' && row[column.key] ? row[column.key].join(', ') : row[column.key]}}
+                                    </span>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>

--- a/resource/pi-system_preview-dataset-modal.html
+++ b/resource/pi-system_preview-dataset-modal.html
@@ -10,6 +10,12 @@
                 <div class="attribute-table-block__title">
                     <strong>{{config.outputSelectedAttributes.length}} selected attribute(s)</strong>
                 </div>
+                <div class="pi-system-preview-dataset-modal__search">
+                    <basic-search-box
+                            ng-model="ui.previewAttributeSearch"
+                            placeholder="Search attribute or element name">
+                    </basic-search-box>
+                </div>
                 <div class="scroll">
                     <div
                             attribute-table-block

--- a/resource/pi-system_preview-dataset-modal.html
+++ b/resource/pi-system_preview-dataset-modal.html
@@ -8,11 +8,11 @@
             <i class="dku-icon-dismiss-16"></i>
             Clear selection
         </button>
-        <div ng-if="!previewRows.length" class="alert alert-info">
+        <div ng-if="!config.outputSelectedAttributes.length" class="alert alert-info">
             No attributes selected yet.
         </div>
-        <div ng-if="previewRows.length">
-            <p>{{previewRows.length}} selected attribute(s)</p>
+        <div ng-if="config.outputSelectedAttributes.length">
+            <p>{{config.outputSelectedAttributes.length}} selected attribute(s)</p>
             <div class="scroll">
                 <table class="table table-striped table-condensed">
                     <thead>
@@ -21,8 +21,13 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr ng-repeat="row in previewRows track by $index">
-                            <td ng-repeat="column in previewColumns">{{row[column.key]}}</td>
+                        <tr ng-repeat-start="(groupKey, subgroup) in previewRows">
+                            <td colspan="{{previewColumns.length}}"><strong>{{subgroup.title}}</strong></td>
+                        </tr>
+                        <tr ng-repeat="row in subgroup.attributes track by row.path" ng-repeat-end>
+                            <td ng-repeat="column in previewColumns">
+                                {{column.key === 'summary_type' && row[column.key] ? row[column.key].join(', ') : row[column.key]}}
+                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/resource/pi-system_preview-dataset-modal.html
+++ b/resource/pi-system_preview-dataset-modal.html
@@ -17,14 +17,21 @@
                 <table class="table table-striped table-condensed">
                     <thead>
                         <tr>
+                            <th></th>
                             <th ng-repeat="column in previewColumns">{{column.label}}</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr ng-repeat-start="(groupKey, subgroup) in previewRows">
-                            <td colspan="{{previewColumns.length}}"><strong>{{subgroup.title}}</strong></td>
+                            <td colspan="{{previewColumns.length + 1}}"><strong>{{subgroup.title}}</strong></td>
                         </tr>
                         <tr ng-repeat="row in subgroup.attributes track by row.path" ng-repeat-end>
+                            <td>
+                                <input
+                                    type="checkbox"
+                                    ng-model="row.checked"
+                                    ng-change="uncheckAttribute(row)">
+                            </td>
                             <td ng-repeat="column in previewColumns">
                                 {{column.key === 'summary_type' && row[column.key] ? row[column.key].join(', ') : row[column.key]}}
                             </td>

--- a/resource/pi-system_preview-dataset-modal.html
+++ b/resource/pi-system_preview-dataset-modal.html
@@ -16,6 +16,8 @@
                             grouped-attributes="groupedSelectedAttributes"
                             config="config"
                             display-path="false"
+                            database-name="config.database_title"
+                            display-group-path="true"
                             elements-by-template="{}"
                             title="'Selected Attributes'"
                             group-mode="None"

--- a/resource/pi-system_preview-dataset-modal.html
+++ b/resource/pi-system_preview-dataset-modal.html
@@ -17,47 +17,27 @@
                     <strong>{{config.outputSelectedAttributes.length}} selected attribute(s)</strong>
                 </div>
                 <div class="scroll">
-                    <table class="custom-table">
-                        <thead>
-                            <tr>
-                                <th></th>
-                                <th ng-repeat="column in previewColumns">{{column.label}}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr
-                                    ng-repeat-start="(groupKey, subgroup) in previewRows"
-                                    class="custom-table__group-row custom-table__group-row--selected">
-                                <td>
-                                    <input
-                                            type="checkbox"
-                                            ng-checked="subgroup.checked_ui"
-                                            ng-click="toggleElementSelection(subgroup)"
-                                            indeterminate="subgroup.checked">
-                                </td>
-                                <td colspan="{{previewColumns.length + 1}}"><strong>{{subgroup.group_name}}</strong></td>
-                            </tr>
-                            <tr
-                                    ng-repeat="row in subgroup.attributes track by row.path"
-                                    ng-repeat-end
-                                    ng-class="{ 'custom-table__attribute-row--selected': row.checked }">
-                                <td>
-                                    <input
-                                        type="checkbox"
-                                        ng-checked="row.checked"
-                                        ng-click="toggleAttributeSelection(row)">
-                                </td>
-                                <td ng-repeat="column in previewColumns">
-                                    <div ng-if="column.key === 'title'" class="custom-table__attribute-title-info">
-                                        {{row[column.key]}}
-                                    </div>
-                                    <span ng-if="column.key !== 'title'">
-                                        {{column.key === 'summary_type' && row[column.key] ? row[column.key].join(', ') : row[column.key]}}
-                                    </span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    <div
+                            attribute-table-block
+                            grouped-attributes="groupedSelectedAttributes"
+                            config="config"
+                            display-path="false"
+                            elements-by-template="{}"
+                            title="'Selected Attributes'"
+                            group-mode="None"
+                            display-element-dropdown="false"
+                            active-tab="None"
+                            aggregate-data-type-fields="aggregateDataTypeFields"
+                            on-toggle-select-all-grouped-attributes="toggleSelectAllGroupedAttributes(groupedAttributeGroup)"
+                            on-toggle-grouped-attributes="toggleGroupedAttributes(group)"
+                            on-is-at-least-partially-selected="isAtLeastPartiallySelected(item)"
+                            on-init-elements-dropdown="initElementsDropdown(templateName)"
+                            on-is-template-associated-element-selected="isTemplateAssociatedElementSelected(element)"
+                            on-apply-click-elements-dropdown="None"
+                            on-check-attribute="checkAttribute(mergedAttribute)"
+                            on-update-data-type="updateMergedAttributeDataType(mergedAttribute)"
+                            on-update-aggregate="updateMergedAttributeAggregate(mergedAttribute)">
+                    </div>
                 </div>
             </div>
         </div>

--- a/resource/pi-system_preview-dataset-modal.html
+++ b/resource/pi-system_preview-dataset-modal.html
@@ -2,12 +2,6 @@
      auto-size="false">
     <div dku-modal-header modal-title="Preview dataset" />
     <div class="modal-body">
-        <button
-                class="btn btn- btn--outline btn--secondary btn--dku-icon"
-                ng-click="clearOutputSelection()">
-            <i class="dku-icon-dismiss-16"></i>
-            Clear selection
-        </button>
         <div ng-if="!config.outputSelectedAttributes.length" class="alert alert-info">
             No attributes selected yet.
         </div>


### PR DESCRIPTION
- **feat: organise selected attributes by element in the preview dataset**
- **feat: working checkbox for preview dataset**
- **feat: checkbox behavior preview dataset**
- **refacto: use the standard attribute table block for the preview dataset modal**
- **cleanup: remove clear selection button**
- **feat: display pretty paths for elements in dropdown elements**
- **fix: broken grouping + feat: finish path display in preview data**
- **feat: search in preview dataset modal**
