### PR TITLE
add get_attributes_per_page endpoint

### DIFF
--- a/js/pi-system_treecontroller.js
+++ b/js/pi-system_treecontroller.js
@@ -384,6 +384,7 @@ app.controller('AfExplorerFormCtrl', [
             attributeValueTypeFilter: '',
             searchResults: [],
             attributeResults: null,
+            nextAttributeResultsPage: null,
             groupedAttributeResults: null,
             groupedAttributeResultsFallbackGrouping: null
         };
@@ -946,25 +947,28 @@ app.controller('AfExplorerFormCtrl', [
             $scope.searchAttributesInDb();
         };
 
-        $scope.searchAttributesInDb = function() {
+        $scope.searchAttributesInDb = function(nextPage) {
             if (!$scope.search.searchString || !$scope.search.searchString.trim()) {
                 return;
             }
 
+            if (!nextPage) {
+                $scope.search.nextAttributeResultsPage = null;
+            }
             startLoadingState(
                 true,
                 "Searching for attributes",
                 "Searching for your query. Loading the attributes can take a little bit of time"
             );
             return $scope.callPythonDo({
-                method: "get_attributes",
+                method: "get_attributes_per_page",
                 attribute_name: $scope.search.searchString,
                 element_category: $scope.search.attributeCategoryFilterList,
-                attribute_value_type: $scope.search.attributeValueTypeFilter
+                attribute_value_type: $scope.search.attributeValueTypeFilter,
+                next_page: nextPage,
             }).then(function(data) {
                 console.log("Attribute search results", data.attributes);
-                // TODO: double check this
-                $scope.search.attributeResults = (data.attributes || []).map(attribute => {
+                const attributes = (data.attributes || []).map(attribute => {
                     const elementPath = getElementPathFromAttributePath(attribute.path);
                     return enrichAttribute({
                         ...attribute,
@@ -973,8 +977,14 @@ app.controller('AfExplorerFormCtrl', [
                         parent_element_path: elementPath
                     }, {});
                 });
+                if (nextPage) {
+                    $scope.search.attributeResults = $scope.search.attributeResults.concat(attributes);
+                } else {
+                    $scope.search.attributeResults = attributes;
+                }
+                $scope.search.nextAttributeResultsPage = data.next_page || null;
                 refreshSearchAttributeResults();
-                console.log("get_attributes", data);
+                console.log("get_attributes_per_page", data);
             }).finally(stopLoadingState);
         };
 
@@ -1015,6 +1025,7 @@ app.controller('AfExplorerFormCtrl', [
             $scope.search.attributeValueTypeFilter = ''
             $scope.search.searchResults = []
             $scope.search.attributeResults = null
+            $scope.search.nextAttributeResultsPage = null
             $scope.search.groupedAttributeResults = null
             $scope.search.groupedAttributeResultsFallbackGrouping = null
             clearSearchHighlights($scope.elementTree);

--- a/python-lib/osisoft_client.py
+++ b/python-lib/osisoft_client.py
@@ -781,6 +781,37 @@ class OSIsoftClient(object):
             else:
                 json_response = None
 
+    def search_attributes_first_page(self, database_webid, **kwargs):
+            search_attributes_base_url = self.endpoint.get_attribute_url()
+            query = "Element:{{{}}} {}".format(
+                self.build_element_query(**kwargs),
+                self.build_attribute_query(**kwargs)
+            )
+            headers = self.get_requests_headers()
+            params = {
+                "query": query,
+                "databaseWebId": database_webid,
+                "maxCount": 5
+            }
+            if "search_associations" in kwargs:
+                params["associations"] = kwargs.get("search_associations")
+            json_response = self.get(url=search_attributes_base_url, headers=headers, params=params)
+            if OSIsoftConstants.DKU_ERROR_KEY in json_response:
+                return json_response, None
+
+            next_page_url = get_next_page_url(json_response)
+            items = json_response.get(OSIsoftConstants.API_ITEM_KEY, [])
+            return items, next_page_url
+
+    def get_next_page(self, page_url):
+        headers = self.get_requests_headers()
+        json_response = self.get(url=page_url, headers=headers, params={})
+        if OSIsoftConstants.DKU_ERROR_KEY in json_response:
+            return json_response, None
+        next_page_url = get_next_page_url(json_response)
+        items = json_response.get(OSIsoftConstants.API_ITEM_KEY, [])
+        return items, next_page_url
+
     def search_elements(self, database, name=None, description=None, category=None, template=None, full_search=True):
         headers = self.get_requests_headers()
         tempo_maxcount = OSIsoftConstants.DEFAULT_MAXCOUNT

--- a/python-lib/osisoft_client.py
+++ b/python-lib/osisoft_client.py
@@ -791,7 +791,7 @@ class OSIsoftClient(object):
             params = {
                 "query": query,
                 "databaseWebId": database_webid,
-                "maxCount": 5
+                "maxCount": 1000
             }
             if "search_associations" in kwargs:
                 params["associations"] = kwargs.get("search_associations")

--- a/resource/browse_af_tree.py
+++ b/resource/browse_af_tree.py
@@ -66,6 +66,8 @@ def do(payload, config, plugin_config, inputs):
         return get_attributes(client, payload, config)
     if method == "build_af_tree":
         return build_af_tree(client, payload, config)
+    if method == "get_attributes_per_page":
+        return get_attributes_per_page(client, payload, config)
     if method == "do_search":
         return do_search(client, payload, config, network_timer)
 
@@ -248,6 +250,54 @@ def get_attributes(client, payload, config):
         "End call [get_attributes] database_name={}, element_name={}, attribute_name={}".format(
             database_name, element_name, attribute_name
         )
+    )
+    return result
+
+def get_attributes_per_page(client, payload, config):
+    next_page = payload.get("next_page", None)
+    if next_page:
+        logger.info(
+            "Start call [get_attributes_per_page] next_page={}".format(
+                next_page
+            )
+        )
+        raw_attributes, next_page = client.get_next_page(next_page)
+    else:
+        database_url = config.get("database_name")
+        database_name = database_url.split("/")[-1]
+        element_name = payload.get("element_name", None)
+        attribute_categories = payload.get("element_category", None)
+        attribute_value_type =  payload.get("attribute_value_type", None)
+        if not element_name:
+            element_name = "*"
+        attribute_name = payload.get("attribute_name", None)
+        logger.info(
+            "Start call [get_attributes_per_page] database_name={}, element_name={}, attribute_name={}".format(
+                database_name, element_name, attribute_name
+            )
+        )
+        raw_attributes, next_page = client.search_attributes_first_page(
+            database_name,
+            attribute_name=attribute_name,
+            element_name=element_name,
+            attribute_category=attribute_categories,
+            attribute_value_type=attribute_value_type,
+            search_associations="Paths",
+            full_search=True
+        )
+    attributes = [get_item_details(attribute) for attribute in raw_attributes]
+    template_urls = [
+        extract_attribute_template_url(attribute)
+        for attribute in raw_attributes
+    ]
+    template_names = client.get_attributes_templates_names(template_urls)
+    for attribute, template_name in zip(attributes, template_names):
+        if template_name:
+            attribute["template_name"] = template_name
+
+    result = {"choices": [], "attributes": attributes, "next_page": next_page}
+    logger.info(
+        "End call [get_attributes_per_page] "
     )
     return result
 

--- a/resource/pi-system_af-explorer.html
+++ b/resource/pi-system_af-explorer.html
@@ -244,6 +244,13 @@
                                 on-update-aggregate="updateMergedAttributeAggregate(mergedAttribute)"
                                 on-update-single-aggregate="updateSingleAttributeAggregate(attribute)">
                         </div>
+                        <div ng-if="search.nextAttributeResultsPage"
+                             style="display: flex; justify-content: center; margin-top: 16px;">
+                            <button class="btn btn--primary"
+                                    ng-click="searchAttributesInDb(search.nextAttributeResultsPage)">
+                                Load more
+                            </button>
+                        </div>
                     </div>
                     <div ng-if="search.searchMode !== 'attribute'">
                         {{getSearchResultCount()}} results


### PR DESCRIPTION
If payload does not contain a `next_page` key, get_attributes_per_page returns first page in `attributes` key and the next page url in the `next_page`
otherwise, it ignores all the other keys and download the content of the next_page url, returns it in the `attributes` along with the next page.